### PR TITLE
Fix prod detection

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -29,7 +29,14 @@
                            :output-to "resources/public/js/compiled/garden_css_modules.js"
                            :output-dir "resources/public/js/compiled/out"
                            :source-map-timestamp true
-                           :preloads [devtools.preload]}}]}
+                           :preloads [devtools.preload]}}
+
+               {:id "min"
+                :source-paths ["src"]
+                :compiler {:output-to "resources/public/js/compiled/garden_css_modules.js"
+                           :main garden-css-modules.example
+                           :optimizations :advanced
+                           :pretty-print false}}]}
 
                ; {:id           "test"
                ;   :source-paths ["src/" "test/cljs"]

--- a/src/garden_css_modules/core.cljc
+++ b/src/garden_css_modules/core.cljc
@@ -1,6 +1,7 @@
 (ns garden-css-modules.core
   #?(:clj
        (:require
+        [cljs.env]
         [clojure.string :as string]
         [garden.core :refer [css]]
         [garden.stylesheet :refer [at-media at-keyframes]]))
@@ -13,10 +14,9 @@
 (defn- get-namespace [] `~(str *ns*))
 
 (defmacro prod? []
-  (if (boolean (:ns &env))
-    `(= :advanced (get-in @cljs.env/*compiler* [:options :optimizations]))
-    `(or (= (System/getenv "ENV") "prod")
-         (= (System/getenv "ENV") "production"))))
+  (if cljs.env/*compiler*
+    (= :advanced (get-in @cljs.env/*compiler* [:options :optimizations]))
+    (string/starts-with? "prod" (System/getenv "ENV"))))
 
 (defn- hash-part [part]
   (if (string/starts-with? part ".")


### PR DESCRIPTION
It works but emits warnings indicating that the separation between CLJ and CLJS is not correct/complete.
That will probably be easier to untangle if we use a plain `.clj` file for the macros
```
WARNING: Use of undeclared Var cljs.env/*compiler* at line 17 /Users/aisamu/rk/garden-css-modules/src/garden_css_modules/core.cljc
WARNING: Use of undeclared Var cljs.env/*compiler* at line 18 /Users/aisamu/rk/garden-css-modules/src/garden_css_modules/core.cljc
WARNING: No such namespace: System, could not locate System.cljs, System.cljc, or JavaScript source providing "System" at line 19 /Users/aisamu/rk/garden-css-modules/src/garden_css_modules/core.cljc
WARNING: Use of undeclared Var System/getenv at line 19 /Users/aisamu/rk/garden-css-modules/src/garden_css_modules/core.cljc
``` 