### PR TITLE
Generate CSS at macro expand time

### DIFF
--- a/src/garden_css_modules/core.cljc
+++ b/src/garden_css_modules/core.cljc
@@ -74,7 +74,7 @@
     (if (boolean (:ns &env))
       `(do
         (~(symbol "garden-css-modules.runtime" "inject-style!")
-          (css {:pretty-print? (not (prod?))} (~module :styles))
+          ~(css {:pretty-print? (not (prod?))} (module :styles))
           (get-namespace)
           ~(name style-id))
         (def ~style-id ~(module :names)))


### PR DESCRIPTION
Attempting to generate CSS in prod mode at macro expansion time causes garden to treat certain vectors as lazy sequences and stringifies the object type name into the CSS. See screenshot:

![image](https://user-images.githubusercontent.com/451066/54812803-68301b80-4c62-11e9-8093-6ed3d655a110.png)

To reproduce:

1. `lein cljsbuild once min`
2. Open resources/public/index.html
3. Inspect contents of injected `<script>` tag within `<head>` tag
